### PR TITLE
add frame imaze size limit

### DIFF
--- a/app/src/app/artworks/[id]/route.tsx
+++ b/app/src/app/artworks/[id]/route.tsx
@@ -71,6 +71,8 @@ const handleRequest = frames(async (ctx) => {
         //   },
         // ],
         aspectRatio: "1:1",
+        width: 500,
+        height: 500,
       },
     };
   } else if (ver === "testnet-2") {
@@ -118,6 +120,8 @@ const handleRequest = frames(async (ctx) => {
         //   },
         // ],
         aspectRatio: "1:1",
+        width: 500,
+        height: 500,
       },
     };
   } else {


### PR DESCRIPTION
## Description

To fix this
<img width="730" alt="Screenshot 2024-06-26 at 10 20 39" src="https://github.com/eistoys/EIS/assets/38043569/974706be-f7dc-4771-99b2-7508f73a002a">

Originally, frame set width and height more than 1000px, so set fixed width and height to prevent that.